### PR TITLE
fix: Fix CI builds

### DIFF
--- a/flashcards/apps/api/v1/views.py
+++ b/flashcards/apps/api/v1/views.py
@@ -1,5 +1,8 @@
+"""
+Django views for the flashcards IDA API
+"""
 from django.views.decorators.http import require_http_methods
-from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.decorators import api_view  # , authentication_classes, permission_classes
 from rest_framework.response import Response
 
 from flashcards.apps.cards.anki import anki_from_block_id
@@ -8,5 +11,5 @@ from flashcards.apps.cards.anki import anki_from_block_id
 @api_view(['GET'])  # TODO get is completely wrong here but convenient for testing
 @require_http_methods(['GET'])
 def cards(request, course_id, block_id):
-    cards = anki_from_block_id(course_id, block_id)
-    return Response(cards)
+    generated_cards = anki_from_block_id(course_id, block_id)
+    return Response(generated_cards)

--- a/flashcards/apps/cards/anki.py
+++ b/flashcards/apps/cards/anki.py
@@ -1,8 +1,9 @@
 """
 Implementation of AnkiConnect to create cards
 """
-from flashcards.apps.cards.cardgen import cards_from_block_id
 import genanki
+
+from flashcards.apps.cards.cardgen import cards_from_block_id
 
 
 def create_anki_cards(openai_data):

--- a/flashcards/apps/cards/anki.py
+++ b/flashcards/apps/cards/anki.py
@@ -47,4 +47,3 @@ def anki_from_block_id(course_id, block_id):
     result = csv_maybe.replace('\t', '')
     create_anki_cards(result)
     return csv_maybe  # return the CSV text so we can see it in testing
-

--- a/flashcards/apps/cards/cardgen.py
+++ b/flashcards/apps/cards/cardgen.py
@@ -3,9 +3,8 @@ from django.conf import settings
 from edx_rest_api_client import client as rest_client
 
 from flashcards.apps.cards.prompt import anki_prompt
-from flashcards.settings.private import OPENAI_API_KEY  # pylint: disable=import-error,no-name-in-module
 
-openai.api_key = OPENAI_API_KEY
+openai.api_key = settings.OPENAI_API_KEY
 
 
 def get_client(oauth_base_url=settings.LMS_ROOT_URL):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,7 @@
 
 # Common constraints for edx repos
 -c common_constraints.txt
+
+# A new deprecation warning inadvertently broke all builds, waiting for a fix
+# https://github.com/pydata/pydata-sphinx-theme/issues/1539
+pydata-sphinx-theme<0.14.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -340,8 +340,10 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.14.2
-    # via sphinx-book-theme
+pydata-sphinx-theme==0.14.1
+    # via
+    #   -c requirements/constraints.txt
+    #   sphinx-book-theme
 pygments==2.16.1
     # via
     #   accessible-pygments


### PR DESCRIPTION
Fix a sort order violation, a direct reference to the private settings that broke doc builds, and pinned pydata-sphinx-theme to avoid a broken release.
